### PR TITLE
feat: Add multilingual support for command type names

### DIFF
--- a/examples/cache_visualization.py
+++ b/examples/cache_visualization.py
@@ -6,144 +6,8 @@ import threading
 import datetime
 import random
 
-# Próba importu bibliotek do wizualizacji
-try:
-    import matplotlib.pyplot as plt
-    import matplotlib.dates as mdates
-    from matplotlib.animation import FuncAnimation
-    VISUALIZATION_AVAILABLE = True
-except ImportError:
-    print("Biblioteka matplotlib nie jest zainstalowana. Wizualizacja nie będzie dostępna.")
-    print("Zainstaluj matplotlib: pip install matplotlib")
-    VISUALIZATION_AVAILABLE = False
-
-class CacheVisualizer:
-    """Klasa do wizualizacji danych z cache'a ShellRunner"""
-    
-    def __init__(self, runner: ShellRunner, update_interval: float = 1.0):
-        """
-        Inicjalizuje wizualizator cache'a.
-        
-        Args:
-            runner: Instancja ShellRunner z włączonym cache
-            update_interval: Interwał odświeżania wizualizacji w sekundach
-        """
-        self.runner = runner
-        self.update_interval = update_interval
-        self.running = False
-        self.thread = None
-        
-        # Dane do wizualizacji
-        self.timestamps = []
-        self.success_counts = []
-        self.error_counts = []
-        self.command_types = {}  # Słownik zliczający typy komend
-        
-        # Inicjalizacja wykresu
-        if VISUALIZATION_AVAILABLE:
-            self.fig, (self.ax1, self.ax2) = plt.subplots(2, 1, figsize=(10, 8))
-            self.fig.suptitle('Wizualizacja cache ShellRunner', fontsize=16)
-            
-            # Wykres historii wykonania komend
-            self.success_line, = self.ax1.plot([], [], 'g-', label='Sukces')
-            self.error_line, = self.ax1.plot([], [], 'r-', label='Błąd')
-            self.ax1.set_title('Historia wykonania komend')
-            self.ax1.set_xlabel('Czas')
-            self.ax1.set_ylabel('Liczba komend')
-            self.ax1.legend()
-            self.ax1.grid(True)
-            
-            # Wykres typów komend (pie chart)
-            self.ax2.set_title('Typy wykonanych komend')
-            
-            # Formatowanie osi czasu
-            self.ax1.xaxis.set_major_formatter(mdates.DateFormatter('%H:%M:%S'))
-            self.ax1.xaxis.set_major_locator(mdates.SecondLocator(interval=5))
-            
-            plt.tight_layout()
-            plt.subplots_adjust(top=0.9)
-    
-    def start(self):
-        """Uruchamia wizualizację w osobnym wątku"""
-        if not VISUALIZATION_AVAILABLE:
-            print("Wizualizacja nie jest dostępna - brak biblioteki matplotlib")
-            return
-            
-        if self.running:
-            return
-            
-        self.running = True
-        self.thread = threading.Thread(target=self._run_visualization)
-        self.thread.daemon = True
-        self.thread.start()
-    
-    def stop(self):
-        """Zatrzymuje wizualizację"""
-        self.running = False
-        if self.thread:
-            self.thread.join(timeout=2.0)
-    
-    def _run_visualization(self):
-        """Główna pętla wizualizacji"""
-        ani = FuncAnimation(self.fig, self._update_plot, interval=self.update_interval*1000)
-        plt.show()
-    
-    def _update_plot(self, frame):
-        """Aktualizuje wykresy na podstawie danych z cache"""
-        # Pobierz dane z cache
-        history = self.runner.get_command_history()
-        stats = self.runner.get_cache_statistics()
-        
-        # Aktualizuj dane historyczne
-        current_time = datetime.datetime.now()
-        self.timestamps.append(current_time)
-        
-        # Ogranicz historię do ostatnich 60 punktów
-        if len(self.timestamps) > 60:
-            self.timestamps = self.timestamps[-60:]
-            self.success_counts = self.success_counts[-60:]
-            self.error_counts = self.error_counts[-60:]
-        
-        # Zlicz sukcesy i błędy
-        success_count = stats.get('success_count', 0)
-        error_count = stats.get('error_count', 0)
-        
-        self.success_counts.append(success_count)
-        self.error_counts.append(error_count)
-        
-        # Aktualizuj wykres historii
-        self.success_line.set_data(self.timestamps, self.success_counts)
-        self.error_line.set_data(self.timestamps, self.error_counts)
-        
-        # Dostosuj zakres osi
-        if self.timestamps:
-            self.ax1.set_xlim(min(self.timestamps), max(self.timestamps))
-            max_count = max(max(self.success_counts, default=0), max(self.error_counts, default=0), 1)
-            self.ax1.set_ylim(0, max_count * 1.1)
-        
-        # Aktualizuj wykres typów komend
-        self.command_types = {}
-        for cmd_id, _, _ in history:
-            # W rzeczywistej implementacji należałoby pobrać typ komendy z cache
-            # Tutaj używamy losowych typów dla demonstracji
-            result = self.runner.get_cached_result(cmd_id)
-            if result:
-                cmd_type = result.metadata.get('command_type', 'unknown') if result.metadata else 'unknown'
-                self.command_types[cmd_type] = self.command_types.get(cmd_type, 0) + 1
-        
-        # Aktualizuj pie chart
-        self.ax2.clear()
-        self.ax2.set_title('Typy wykonanych komend')
-        if self.command_types:
-            self.ax2.pie(
-                self.command_types.values(), 
-                labels=self.command_types.keys(),
-                autopct='%1.1f%%', 
-                startangle=90
-            )
-            self.ax2.axis('equal')
-        
-        return self.success_line, self.error_line
+# Usunięto całą sekcję importu matplotlib
+VISUALIZATION_AVAILABLE = False
 
 def simulate_commands(runner, count=20, interval=0.5):
     """Symuluje wykonanie różnych komend dla celów demonstracyjnych"""
@@ -164,19 +28,31 @@ def simulate_commands(runner, count=20, interval=0.5):
     
     for i in range(count):
         cmd = random.choice(commands)
-        # Dodajemy losowe metadane dla celów demonstracyjnych
-        cmd_type = cmd._command_name if hasattr(cmd, '_command_name') else "unknown"
+        
+        # Pobierz nazwę polecenia przed wykonaniem
+        cmd_name = cmd.name if hasattr(cmd, 'name') else "unknown"
+        cmd_type = runner.get_command_type_name(cmd_name)
+        
+        # Pobierz pełne polecenie
+        cmd_string = cmd.build_command() if hasattr(cmd, 'build_command') else str(cmd)
         
         # Wykonujemy komendę z dodatkowymi metadanymi
+        print(f"Wykonuję komendę: {cmd_string}")
         result = runner.execute(cmd)
         
-        # Dodajemy metadane do wyniku (w rzeczywistej implementacji należałoby to zrobić inaczej)
-        if hasattr(result, 'metadata') and result.metadata is None:
-            result.metadata = {}
-        if hasattr(result, 'metadata'):
-            result.metadata['command_type'] = cmd_type
-        
         print(f"Wykonano komendę {i+1}/{count}: {cmd_type}")
+        print(f"  Status: {'Sukces' if result.is_success() else 'Błąd'}")
+        print(f"  Exit Code: {result.exit_code}")
+        if result.raw_output:
+            # Jeśli jest wyjście, wyświetl pierwsze 3 linie (lub mniej)
+            output_lines = result.raw_output.strip().split('\n')
+            if output_lines and output_lines[0]:
+                sample = '\n    '.join(output_lines[:3])
+                print(f"  Wyjście (fragment): {sample}")
+                if len(output_lines) > 3:
+                    print(f"    ... (oraz {len(output_lines) - 3} więcej linii)")
+        print()
+        
         time.sleep(interval)
 
 def main():
@@ -186,48 +62,75 @@ def main():
         enable_cache=True,
         cache_max_size=200,
         cache_auto_refresh=True,
-        cache_refresh_interval=10
+        cache_refresh_interval=10,
+        language="pl"  # Ustawiamy język polski dla nazw komend
     )
     
-    print("=== Demonstracja wizualizacji cache w ShellRunner ===\n")
+    print("=== Demonstracja cache w ShellRunner (z obsługą języków) ===\n")
     
-    if VISUALIZATION_AVAILABLE:
-        # Inicjalizacja wizualizatora
-        visualizer = CacheVisualizer(runner, update_interval=1.0)
+    # Wyświetlamy dostępne języki
+    available_languages = runner.get_available_languages()
+    print(f"Dostępne języki: {', '.join(available_languages)}")
+    print(f"Aktualny język: {runner.language}\n")
+    
+    # Symulujemy komendy
+    print("Symulacja wykonania komend...")
+    simulate_commands(runner, count=5, interval=0.5)
+    
+    # Wyświetlamy statystyki cache
+    print("\nStatystyki cache:")
+    stats = runner.get_cache_statistics()
+    print(json.dumps(stats, indent=2))
+    
+    # Wyświetlamy historię komend
+    print("\nHistoria wykonanych komend:")
+    history = runner.get_command_history()
+    
+    for i, (cmd_id, timestamp, success) in enumerate(history):
+        # Wyświetlamy podstawowe informacje
+        print(f"{i+1}. ID: {cmd_id[:8]}...")
+        print(f"   Czas: {timestamp}")
+        print(f"   Status: {'Sukces' if success else 'Błąd'}")
         
-        # Uruchomienie wizualizacji w osobnym wątku
-        visualizer.start()
-        
-        # Symulacja wykonania komend
-        print("Symulacja wykonania komend...")
-        simulate_commands(runner, count=30, interval=0.3)
-        
-        print("\nWizualizacja działa w osobnym oknie.")
-        print("Naciśnij Ctrl+C, aby zakończyć.")
-        
-        try:
-            # Czekamy na zamknięcie okna wizualizacji
-            while visualizer.running:
-                time.sleep(0.5)
-        except KeyboardInterrupt:
-            print("\nPrzerwano przez użytkownika.")
-        finally:
-            visualizer.stop()
-    else:
-        # Jeśli wizualizacja nie jest dostępna, po prostu symulujemy komendy
-        print("Symulacja wykonania komend bez wizualizacji...")
-        simulate_commands(runner, count=10, interval=0.5)
-        
-        # Wyświetlamy statystyki cache
-        print("\nStatystyki cache:")
-        stats = runner.get_cache_statistics()
-        print(json.dumps(stats, indent=2))
-        
-        # Wyświetlamy historię komend
-        print("\nHistoria wykonanych komend:")
-        history = runner.get_command_history()
-        for i, (cmd_id, timestamp, success) in enumerate(history):
-            print(f"{i+1}. ID: {cmd_id[:8]}... | Czas: {timestamp} | Status: {'Sukces' if success else 'Błąd'}")
+        # Pobieramy wynik z cache
+        result = runner.get_cached_result(cmd_id)
+        if result and hasattr(result, 'metadata') and result.metadata:
+            # Pobieramy typ komendy z metadanych
+            cmd_type = result.metadata.get('command_type', 'unknown')
+            cmd_string = result.metadata.get('command_string', 'unknown')
+            
+            # Wyświetlamy polską nazwę komendy, używając metody z frameworka
+            polish_cmd_name = runner.get_command_type_name(cmd_type)
+            print(f"   Typ komendy: {polish_cmd_name}")
+            print(f"   Polecenie: {cmd_string}")
+            
+            # Wyświetlamy exit code i fragmenty wyniku
+            print(f"   Exit Code: {result.exit_code}")
+            if result.raw_output:
+                # Jeśli jest wyjście, wyświetl pierwsze 2 linie (lub mniej)
+                output_lines = result.raw_output.strip().split('\n')
+                if output_lines and output_lines[0]:
+                    sample = '\n    '.join(output_lines[:2])
+                    print(f"   Wyjście (fragment): {sample}")
+                    if len(output_lines) > 2:
+                        print(f"    ... (oraz {len(output_lines) - 2} więcej linii)")
+        print()
+    
+    # Przykład zmiany języka
+    print("\nZmiana języka na angielski:")
+    runner.set_language("en")
+    
+    # Wyświetlamy to samo polecenie w innym języku
+    if history and len(history) > 0:
+        cmd_id = history[0][0]
+        result = runner.get_cached_result(cmd_id)
+        if result and result.metadata and 'command_type' in result.metadata:
+            cmd_type = result.metadata['command_type']
+            pl_name = runner.get_command_type_name(cmd_type, "pl")
+            en_name = runner.get_command_type_name(cmd_type, "en")
+            print(f"Polecenie {cmd_type}:")
+            print(f"   - po polsku: {pl_name}")
+            print(f"   - po angielsku: {en_name}")
 
 if __name__ == "__main__":
     main() 

--- a/src/mancer/application/shell_runner.py
+++ b/src/mancer/application/shell_runner.py
@@ -10,17 +10,91 @@ from .command_cache import CommandCache
 import uuid
 import hashlib
 
+# Definicje typów komend w różnych językach
+COMMAND_TYPES_TRANSLATION = {
+    "pl": {
+        "ls": "Lista plików",
+        "ps": "Procesy systemowe",
+        "hostname": "Nazwa hosta",
+        "netstat": "Status sieci",
+        "systemctl": "Kontrola usług",
+        "df": "Użycie dysku",
+        "echo": "Wyświetlanie tekstu",
+        "cat": "Wyświetlanie pliku",
+        "grep": "Wyszukiwanie wzorca",
+        "tail": "Koniec pliku",
+        "head": "Początek pliku",
+        "find": "Wyszukiwanie plików",
+        "cp": "Kopiowanie plików",
+        "mv": "Przenoszenie plików",
+        "rm": "Usuwanie plików",
+        "mkdir": "Tworzenie katalogów",
+        "chmod": "Zmiana uprawnień",
+        "chown": "Zmiana właściciela",
+        "tar": "Archiwizacja",
+        "zip": "Kompresja",
+        "unzip": "Dekompresja",
+        "ssh": "Połączenie SSH",
+        "scp": "Kopiowanie przez SSH",
+        "wget": "Pobieranie plików",
+        "curl": "Klient HTTP",
+        "apt": "Zarządzanie pakietami",
+        "yum": "Zarządzanie pakietami",
+        "dnf": "Zarządzanie pakietami",
+        "ping": "Test połączenia",
+        "traceroute": "Śledzenie trasy",
+        "ifconfig": "Konfiguracja sieci",
+        "ip": "Zarządzanie IP"
+    },
+    "en": {
+        "ls": "File listing",
+        "ps": "Process status",
+        "hostname": "Host name",
+        "netstat": "Network status",
+        "systemctl": "Service control",
+        "df": "Disk usage",
+        "echo": "Text display",
+        "cat": "File display",
+        "grep": "Pattern search",
+        "tail": "File end",
+        "head": "File beginning",
+        "find": "File search",
+        "cp": "Copy files",
+        "mv": "Move files",
+        "rm": "Remove files",
+        "mkdir": "Create directories",
+        "chmod": "Change permissions",
+        "chown": "Change owner",
+        "tar": "Archive",
+        "zip": "Compress",
+        "unzip": "Decompress",
+        "ssh": "SSH connection",
+        "scp": "SSH copy",
+        "wget": "Download files",
+        "curl": "HTTP client",
+        "apt": "Package management",
+        "yum": "Package management",
+        "dnf": "Package management",
+        "ping": "Connection test",
+        "traceroute": "Trace route",
+        "ifconfig": "Network configuration",
+        "ip": "IP management"
+    }
+}
+
 class ShellRunner:
     """Główna klasa aplikacji do uruchamiania komend"""
     
     def __init__(self, backend_type: str = "bash", working_dir: str = ".", 
                 enable_cache: bool = False, cache_max_size: int = 100,
-                cache_auto_refresh: bool = False, cache_refresh_interval: int = 5):
+                cache_auto_refresh: bool = False, cache_refresh_interval: int = 5,
+                language: str = "pl"):
         self.backend_type = backend_type
         self.factory = CommandFactory(backend_type)
         self.context = CommandContext(current_directory=working_dir)
         self.local_backend = BashBackend()
         self.remote_backend = None
+        self.language = language
         
         # Inicjalizacja cache'a
         self._cache_enabled = enable_cache
@@ -60,13 +134,24 @@ class ShellRunner:
         # Zapisujemy wynik w cache'u, jeśli cache jest włączony
         if self._cache_enabled and result:
             command_str = str(command)
+            
+            # Pobieramy typ komendy (nazwę klasy lub nazwę komendy)
+            command_type = command.__class__.__name__
+            if hasattr(command, 'name'):
+                command_type = command.name
+                
+            # Pobieramy pełne polecenie
+            command_string = command.build_command() if hasattr(command, 'build_command') else str(command)
+            
             metadata = {
                 'context': {
                     'current_directory': context.current_directory,
                     'execution_mode': str(context.execution_mode),
                     'remote_host': str(context.remote_host) if context.remote_host else None
                 },
-                'params': context_params
+                'params': context_params,
+                'command_type': command_type,
+                'command_string': command_string
             }
             self._command_cache.store(cache_id, command_str, result, metadata)
             
@@ -269,11 +354,26 @@ class ShellRunner:
             command_id: Identyfikator komendy
             
         Returns:
-            Wynik komendy lub None, jeśli nie znaleziono lub cache jest wyłączony
+            Wynik komendy lub None, jeśli nie znaleziono lub cache wyłączony
         """
-        if self._cache_enabled and self._command_cache:
-            return self._command_cache.get(command_id)
-        return None
+        if not self._cache_enabled or not self._command_cache:
+            return None
+            
+        result = self._command_cache.get(command_id)
+        
+        # Pobierz również metadane z cache i dodaj je do wyniku
+        if result:
+            metadata_entry = self._command_cache.get_with_metadata(command_id)
+            if metadata_entry and len(metadata_entry) > 2:
+                _, _, meta_dict = metadata_entry
+                if meta_dict and 'metadata' in meta_dict:
+                    # Zaktualizuj metadane w wyniku, zachowując istniejące
+                    if result.metadata is None:
+                        result.metadata = meta_dict['metadata']
+                    else:
+                        result.metadata.update(meta_dict['metadata'])
+                        
+        return result
     
     def export_cache_data(self, include_results: bool = True) -> Dict[str, Any]:
         """
@@ -288,3 +388,42 @@ class ShellRunner:
         if self._cache_enabled and self._command_cache:
             return self._command_cache.export_data(include_results)
         return {}
+
+    def get_command_type_name(self, command_type: str, language: Optional[str] = None) -> str:
+        """
+        Zwraca nazwę typu komendy w określonym języku.
+        
+        Args:
+            command_type: Typ komendy (np. 'ls', 'ps')
+            language: Kod języka ('pl', 'en'), domyślnie używa języka ustawionego w instancji
+            
+        Returns:
+            Nazwa typu komendy lub command_type jeśli brak tłumaczenia
+        """
+        lang = language or self.language
+        if lang not in COMMAND_TYPES_TRANSLATION:
+            return command_type
+            
+        translations = COMMAND_TYPES_TRANSLATION[lang]
+        return translations.get(command_type, command_type)
+    
+    def set_language(self, language: str) -> None:
+        """
+        Ustawia język dla nazw komend.
+        
+        Args:
+            language: Kod języka ('pl', 'en')
+        """
+        if language in COMMAND_TYPES_TRANSLATION:
+            self.language = language
+        else:
+            raise ValueError(f"Nieobsługiwany język: {language}")
+            
+    def get_available_languages(self) -> List[str]:
+        """
+        Zwraca listę dostępnych języków.
+        
+        Returns:
+            Lista kodów języków
+        """
+        return list(COMMAND_TYPES_TRANSLATION.keys())


### PR DESCRIPTION
- Add COMMAND_TYPES_TRANSLATION dictionary with Polish and English translations

- Add language parameter to ShellRunner constructor

- Implement get_command_type_name() method for command type translations

- Add set_language() and get_available_languages() methods

- Update cache_visualization.py example to use new multilingual features

- Remove local command name translations from example

- Add language switching demonstration in example